### PR TITLE
Changed optional values of steamid, appid and contextid

### DIFF
--- a/api.json
+++ b/api.json
@@ -5442,19 +5442,19 @@
                 {
                     "name": "steamid",
                     "type": "fixed64",
-                    "optional": true,
+                    "optional": false,
                     "description": ""
                 },
                 {
                     "name": "appid",
                     "type": "uint32",
-                    "optional": true,
+                    "optional": false,
                     "description": ""
                 },
                 {
                     "name": "contextid",
                     "type": "uint64",
-                    "optional": true,
+                    "optional": false,
                     "description": ""
                 },
                 {


### PR DESCRIPTION
For the [endpoint GetInventoryItemsWithDescriptions](https://steamapi.xpaw.me/#IEconService/GetInventoryItemsWithDescriptions) if the parameters steamid, appid and contextid are not provided, a dictionary object with no data returns:
`{
"response": {}
}`
I edited the requirement of these parameters.